### PR TITLE
Fix errors in docs

### DIFF
--- a/docs/aiohttp_intro.rst
+++ b/docs/aiohttp_intro.rst
@@ -60,7 +60,7 @@ The file ``sync_pep_8010.html`` will be created.
 -----------
 
 Let's take the next 10-15 minutes to write a script that will programmatically
-download PEPs 8010 to 8016 using `requests`_ library.
+download PEPs 8010 to 8015 using `requests`_ library.
 
 Solution
 --------
@@ -130,7 +130,7 @@ The code is looking more complex than when we're doing it synchronously, using
 resource using aiohttp, now you can download multiple pages asynchronously.
 
 Let's take the next 10-15 minutes to write the script for downloading PEPs
-8010 - 8016 using aiohttp.
+8010 - 8015 using aiohttp.
 
 
 Solution

--- a/docs/aiohttp_server.rst
+++ b/docs/aiohttp_server.rst
@@ -116,7 +116,7 @@ Another way to parametrize resource is by using query parameters, for example
 
         return web.Response(text=f"Hello, {user} {page_num}")
 
-Now try going to http://0.0.0.0:8080/<student>/?page=<pagenum>.
+Now try going to http://0.0.0.0:8080/<student>?page=<pagenum>.
 
 Serving other methods (POST, PUT, etc)
 --------------------------------------


### PR DESCRIPTION
This PR fixes the following errors in the docs:

**aiohttp_intro.rst:**
The demonstrated code downloads PEPs 8010 - 8015, not 8010 - 8016

**aiohttp_server.rst:**
The handler is routed to `/{username}` and not `/{username}/`,
so learners should be visiting `http://0.0.0.0:8080/<student>?page=<pagenum>`
and not `http://0.0.0.0:8080/<student>/?page=<pagenum>`